### PR TITLE
Saves flows as a multiline json file

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -65,7 +65,7 @@ module.exports = {
 
     // To enabled pretty-printing of the flow within the flow file, set the following
     //  property to true:
-    //flowFilePretty: true,
+    flowFilePretty: true,
 
     // By default, credentials are encrypted in storage using a generated key. To
     // specify your own secret, set the following property.


### PR DESCRIPTION
By default, node-red stores its flows as a single line blob of
characters. That makes it very hard for PR reviewers to understand
whats changed in the commit (like this one
https://github.com/share-research/share-red-flows/commit/3019c51025ead7412a9776aa0701d063767a087d )

Note: You will need to restart node-red and redeploy a flow to see the pretty formatted flow.